### PR TITLE
[fix] .rubocop.yml 修正

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ require:
 AllCops:
   # Ruby バージョン指定
   TargetRubyVersion: 2.7.1
-  TergetRailsVersion: 5.2.4.3
+
   # 除外
   Exclude:
     - 'vendor/**/*' # rubocop config/default.yml


### PR DESCRIPTION
## 概要

TargetRailsVersionで警告が出ていたため修正した。

## 詳細

- .rubocop.yml
    - `TargetRailsVersion: 5.2.4.3` の記述を削除